### PR TITLE
Add run-time dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ account) in the Release tab of this repo, and hopefully it will be packaged as a
 I currently don't see how to make it).
 
 **Dependencies (at runtime):** libadwaita, libimobiledevice, libplist-2.X (I attempted to support both 2.2
-and 2.3). OpenSSL is currently also needed, but I plan to remove that dependency as soon
+and 2.3), usbmuxd. OpenSSL is currently also needed, but I plan to remove that dependency as soon
 as possible (only networking is requiring it).
 
 *Note:* On Windows, MSVC builds of those libraries are needed as sideloader is built with MSVC.


### PR DESCRIPTION
I encountered this error when running the program on Arch Linux:
`linker.Exception.LinkException@../../../.dub/packages/gtk_d/1.0.3/gtk_d/source/linker/linker/Loader.d(98): Library load failed (libadwaita-1.so.0): libadwaita-1.so.0: cannot open shared object file: No such file or directory`
I fixed this problem by installing the `libadwaita` package.