### PR TITLE
fix: use addHeaders to set 'security-code' header for request

### DIFF
--- a/source/server/appleaccount.d
+++ b/source/server/appleaccount.d
@@ -159,7 +159,7 @@ package class AppleAccount {
             AppleSecondaryActionResponse delegate(string) submitCode;
             if (urlBagKey == "trustedDeviceSecondaryAuth") {
                 submitCode = (string code) {
-                    request.headers["security-code"] = code;
+                    request.addHeaders(["security-code": code]);
                     auto codeValidationPlist = Plist.fromXml(request.get(urls["validateCode"]).responseBody().data!string()).dict();
                     log.traceF!"Trusted device 2FA response: %s"(codeValidationPlist.toXml());
                     auto resultCode = codeValidationPlist["ec"].uinteger().native();


### PR DESCRIPTION
This PR fixes a build-breaking issue caused by the old way of setting request headers.
Previously, the code attempted to assign a header directly using:
```d
request.headers["security-code"] = code
```
However, this no longer works on my machine or any machine I've tested it on
The fix replaces that line with the appropriate API method:
```d
request.addHeaders(["security-code": code])
```