### PR TITLE
ci(cli): build macOS binaries natively to fix SG_READ_ONLY launch crash (#103)

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -13,43 +13,77 @@ jobs:
         include:
           - triple: 'x86_64-linux-gnu'
             target: 'linux'
+            os: 'ubuntu-22.04'
+            native: false
 
           - triple: 'aarch64-linux-gnu'
             target: 'linux'
+            os: 'ubuntu-22.04'
+            native: false
 
           - triple: 'x86_64-windows-msvc'
             target: 'windows'
+            os: 'ubuntu-22.04'
+            native: false
 
           - triple: 'aarch64-windows-msvc'
             target: 'windows'
+            os: 'ubuntu-22.04'
+            native: false
 
+          # macOS targets are built natively on macOS runners. Cross-linking
+          # them from Linux with lld + an old SDK produces a Mach-O whose
+          # __DATA_CONST segment lacks the SG_READ_ONLY flag, which the dyld on
+          # recent macOS rejects at launch ("__DATA_CONST segment missing
+          # SG_READ_ONLY flag"). See issue #103. Building with the system
+          # toolchain (ld64) emits a correct, launchable binary.
           - triple: 'x86_64-apple-darwin'
             target: 'macos'
+            os: 'macos-13'
+            native: true
 
           - triple: 'arm64-apple-macos'
             target: 'macos'
+            os: 'macos-14'
+            native: true
 
     name: Build CLI for ${{ matrix.triple }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
 
       - name: Update APT repos
+        if: ${{ !matrix.native }}
         run: sudo apt-get update
 
-      - name: Set-up D compiler
+      # Cross-compilation path (Linux and Windows targets, built from Ubuntu).
+      - name: Set-up D compiler (cross)
+        if: ${{ !matrix.native }}
         uses: ./.github/actions/setup-d-compiler
         with:
           target-triple: ${{ matrix.triple }}
 
+      # Native path (macOS targets, built on macOS runners with the system
+      # linker so the resulting binary launches on modern macOS).
+      - name: Set-up D compiler (native)
+        if: ${{ matrix.native }}
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ldc-1.41.0
+
       - name: Write version file
         uses: ./.github/actions/write-version-file
 
-      - name: Build
+      - name: Build (cross)
+        if: ${{ !matrix.native }}
         run: dub build -b release-debug --compiler=ldc2 --arch ${{ matrix.triple }} :cli-frontend
+
+      - name: Build (native)
+        if: ${{ matrix.native }}
+        run: dub build -b release-debug --compiler=ldc2 :cli-frontend
 
       - name: Move files around for artifcation
         uses: ./.github/actions/rename-files


### PR DESCRIPTION
## Problem

The prebuilt **macOS CLI binaries do not launch on recent macOS**. Both
the arm64 and x86_64 artifacts immediately abort with:

```
dyld[…]: __DATA_CONST segment missing SG_READ_ONLY flag
```

This is issue #103, and is also the underlying reason behind the macOS
"App crash" reports (#107).

## Root cause

`build-cli.yml` builds **every** target — including the two macOS
triples — on `ubuntu-22.04`, cross-linking them via
`./.github/actions/target-arm64-apple-macos` /
`target-x86_64-apple-darwin`. Those actions pin **`lld-15`** and the
**MacOSX11.0 SDK** with `-mmacosx-version-min=12.6`.

`lld-15` does not set the `SG_READ_ONLY` flag on the `__DATA_CONST`
segment. Older macOS tolerated this; the dyld on current macOS (Sonoma+,
and notably macOS 26) treats it as a hard error and refuses to launch the
image. So the cross-linked binaries are dead-on-arrival on modern systems.

## Fix

Build the macOS targets **natively** on macOS runners (`macos-13` for
x86_64, `macos-14` for arm64) with the system toolchain (`ld64`), which
emits a Mach-O with the correct segment flags. Linux and Windows targets
keep the existing cross-compile path unchanged. The matrix gains `os` and
`native` keys; `runs-on` is now `${{ matrix.os }}`, and the
setup/build steps branch on `matrix.native`.

## Verification

Built locally on an Apple Silicon Mac (macOS 26.3) from this branch with
the same compiler the CI uses (LDC 1.41.0), native target:

```
dub build -b release-debug --compiler=ldc2 :cli-frontend
```

Result — the `__DATA_CONST` segment now carries `SG_READ_ONLY` (`0x10`):

```
$ otool -l bin/sideloader | grep -A1 __DATA_CONST
  segname __DATA_CONST
  …
      flags 0x10
```

…and the binary launches and runs correctly (the cross-linked artifact
printed nothing / segfaulted on the same machine):

```
$ ./bin/sideloader version
Sideloader, compiled locally with LDC on Jun 23 2026 …
$ ./bin/sideloader --help
Usage: sideloader [-d] [--thread-count THREADCOUNT] [-h] <command> [<args>]
Available commands: app-id  cert  device  install  sign  trollsign  team  tool  version
```

## Notes

- Targeted at `update-ldc` because that is where the toolchain/botan
  updates (LDC 1.41.0) live and where the sources compile cleanly — the
  same native build also resolves the botan compile failure reported in
  #109. The CI change itself is independent and applies to `main` once
  those dependency fixes land there.
- I could not exercise the GitHub-hosted macOS runners themselves; the
  native build is verified locally, the workflow wiring is review-only.

Fixes #103.
